### PR TITLE
Add npm audit fix force and control + c notes to set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ The details of this project are outline in [this project spec](http://frontend.t
 1. Within your group, decide on one person to have the project repository (repo) on their GitHub account. Then, that person should fork this repo - on the top right corner of this page, click the **Fork** button.
 1. Both memebers of the group should clone down the _forked_ repo. Since you don't want to name your project "activity-tracker-starter", you can use an optional argument when you run git clone (you replace the [...] with the terminal command arguments): `git clone [remote-address] [what you want to name the repo]`
 1. Once you have cloned the repo, change into the directory and install the project dependencies. Run `npm install` to install project dependencies.
-1. Run `npm start` in the terminal to see the HTML page (you should see some boilerplate HTML displayed on the page)
-1. Make sure both members of your team are collaborators on the forked repo.
+1. Run `npm start` in the terminal to see the HTML page (you should see some boilerplate HTML displayed on the page).  `Control + C` is the command to stop running the local server.  Closing the terminal without stopping the server first could allow the server to continue to run in the background and cause problems. This command is not specific to Webpack; make note of it for future use.   
+1. Make sure both members of your team are collaborators on the forked repo.  
+1. Do not run `npm audit fix --force`.  This will update to the latest version of packages.  We need to be using `webpack-dev-server@3.11.2` which is not the latest version.  If you start to run into Webpack errors, first check that all group members are using the correct version.  
 
 ## Testing
 


### PR DESCRIPTION
To help prevent students from running into common errors and getting into the weeds with Webpack, added the following two notes to the Set up instructions
- Do use `control + c` to stop the server from running locally before you close the terminal
- Do not use `npm audit fix --force`